### PR TITLE
TFP-5705 Innføre dato som overstyrer regelvalg

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/Minsterett.java
+++ b/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/Minsterett.java
@@ -20,7 +20,7 @@ public enum Minsterett {
 
     public static Map<Minsterett, Integer> finnMinsterett(BeregnMinsterettGrunnlag grunnlag) {
 
-        var fhDato = grunnlag.getFamilieHendelseDato();
+        var regeldato = grunnlag.getKonfigurasjonsvalgdato();
         var retter = new EnumMap<Minsterett, Integer>(Minsterett.class);
         var minsterett = grunnlag.isMinsterett();
         var morHarUføretrygd = grunnlag.isMorHarUføretrygd();
@@ -32,30 +32,30 @@ public enum Minsterett {
         ;
         if (minsterett && grunnlag.isGjelderFødsel()) {
             // Settes for begge parter. Brukes ifm berørt for begge og fakta uttak for far.
-            retter.put(Minsterett.FAR_UTTAK_RUNDT_FØDSEL, Konfigurasjon.STANDARD.getParameter(Parametertype.FAR_DAGER_RUNDT_FØDSEL, null, fhDato));
+            retter.put(Minsterett.FAR_UTTAK_RUNDT_FØDSEL, Konfigurasjon.STANDARD.getParameter(Parametertype.FAR_DAGER_RUNDT_FØDSEL, null, regeldato));
         }
 
         if (minsterett && bareFarHarRett && !aleneomsorg) {
             sjekkBareFarRettMinsterett(grunnlag)
                 .ifPresent(mr -> retter.put(Minsterett.GENERELL_MINSTERETT, mr));
         } else if (morHarUføretrygd && bareFarHarRett && !aleneomsorg) {
-            var antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.BARE_FAR_RETT_MOR_UFØR_DAGER_UTEN_AKTIVITETSKRAV, grunnlag.getDekningsgrad(), fhDato);
+            var antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.BARE_FAR_RETT_MOR_UFØR_DAGER_UTEN_AKTIVITETSKRAV, grunnlag.getDekningsgrad(), regeldato);
             retter.put(Minsterett.UTEN_AKTIVITETSKRAV, antallDager);
         }
         return retter;
     }
 
     private static Optional<Integer> sjekkToTette(BeregnMinsterettGrunnlag grunnlag) {
-        var fhDato = grunnlag.getFamilieHendelseDato();
-        var toTette = toTette(grunnlag.getFamilieHendelseDato(), grunnlag.getFamilieHendelseDatoNesteSak());
+        var regeldato = grunnlag.getKonfigurasjonsvalgdato();
+        var toTette = toTette(regeldato, grunnlag.getFamilieHendelseDato(), grunnlag.getFamilieHendelseDatoNesteSak());
         if (grunnlag.isMinsterett() && toTette) {
             var antallDager = 0;
             if (grunnlag.isMor() && grunnlag.isGjelderFødsel()) {
-                antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.MOR_TETTE_SAKER_DAGER_FØDSEL, null, fhDato);
+                antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.MOR_TETTE_SAKER_DAGER_FØDSEL, null, regeldato);
             } else if (grunnlag.isMor()) {
-                antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.MOR_TETTE_SAKER_DAGER_ADOPSJON, null, fhDato);
+                antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.MOR_TETTE_SAKER_DAGER_ADOPSJON, null, regeldato);
             } else {
-                antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.FAR_TETTE_SAKER_DAGER_MINSTERETT, null, fhDato);
+                antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.FAR_TETTE_SAKER_DAGER_MINSTERETT, null, regeldato);
             }
             return Optional.of(antallDager);
         } else if (grunnlag.getFamilieHendelseDatoNesteSak() != null){
@@ -66,18 +66,18 @@ public enum Minsterett {
     }
 
     private static Optional<Integer> sjekkBareFarRettMinsterett(BeregnMinsterettGrunnlag grunnlag) {
-        var fhDato = grunnlag.getFamilieHendelseDato();
+        var regeldato = grunnlag.getKonfigurasjonsvalgdato();
         var morHarUføretrygd = grunnlag.isMorHarUføretrygd();
-        var antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.BARE_FAR_RETT_DAGER_MINSTERETT, null, fhDato);
+        var antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.BARE_FAR_RETT_DAGER_MINSTERETT, null, regeldato);
         var flerbarnDager = 0;
         if (morHarUføretrygd) {
-            antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.BARE_FAR_RETT_MOR_UFØR_DAGER_MINSTERETT, grunnlag.getDekningsgrad(), fhDato);
+            antallDager = Konfigurasjon.STANDARD.getParameter(Parametertype.BARE_FAR_RETT_MOR_UFØR_DAGER_MINSTERETT, grunnlag.getDekningsgrad(), regeldato);
         }
         if (grunnlag.getAntallBarn() == 2) {
-            flerbarnDager = Konfigurasjon.STANDARD.getParameter(Parametertype.EKSTRA_DAGER_TO_BARN, grunnlag.getDekningsgrad(), fhDato);
+            flerbarnDager = Konfigurasjon.STANDARD.getParameter(Parametertype.EKSTRA_DAGER_TO_BARN, grunnlag.getDekningsgrad(), regeldato);
         }
         if (grunnlag.getAntallBarn() > 2) {
-            flerbarnDager = Konfigurasjon.STANDARD.getParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN, grunnlag.getDekningsgrad(), fhDato);
+            flerbarnDager = Konfigurasjon.STANDARD.getParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN, grunnlag.getDekningsgrad(), regeldato);
         }
         if (flerbarnDager > 0) {
             var dagerFørTilleggAvFlerbarn = morHarUføretrygd ? antallDager : 0;
@@ -91,11 +91,11 @@ public enum Minsterett {
     }
 
 
-    private static boolean toTette(LocalDate familieHendelseDato, LocalDate familieHendelseDatoNesteSak) {
+    private static boolean toTette(LocalDate regeldato, LocalDate familieHendelseDato, LocalDate familieHendelseDatoNesteSak) {
         if (familieHendelseDatoNesteSak == null) {
             return false;
         }
-        var toTetteGrense = Konfigurasjon.STANDARD.getParameter(Parametertype.TETTE_SAKER_MELLOMROM_UKER, null, familieHendelseDato);
+        var toTetteGrense = Konfigurasjon.STANDARD.getParameter(Parametertype.TETTE_SAKER_MELLOMROM_UKER, null, regeldato);
         var grenseToTette = familieHendelseDato.plus(Period.ofWeeks(toTetteGrense)).plusDays(1);
         return grenseToTette.isAfter(familieHendelseDatoNesteSak);
     }

--- a/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnKontoerGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnKontoerGrunnlag.java
@@ -8,6 +8,18 @@ import no.nav.fpsak.nare.doc.RuleDocumentationGrunnlag;
 @RuleDocumentationGrunnlag
 public class BeregnKontoerGrunnlag {
 
+    /*
+     * Normalt velges konti ut fra fødselsdato/termindato/omsorgsdato.
+     * Normalt vil endringer tre i kraft "for nye tilfelle" - som enten går på familiehendelsedato eller på første uttaksdato.
+     * For regler som gjelder begge foreldrene brukes gjerne familiehendelsesdato. Andre regler som er mer individuelt orientert ser gjerne på uttaksdato
+     *
+     * For tilfelle terminbasert søknad så vil man på søknadstidspunktet ikke nødvendigvis vite om fødselsdato tilsier annet regelverk enn termin.
+     * Dessuten trer nye regler først i kraft når dagens dato har passert ikraftredelsesdato for endrete regler - må innvilges på gamle regler inntil nye trer i kraft
+     *
+     * Parameter regelvalgsdato settes kun når man ønsker å "overstyre" familiehendelsedato for regelvalg og kan brukes i utviklingsmiljø + produksjon fram til ikrafttredelse.
+     */
+    private LocalDate regelvalgsdato;
+
     private int antallBarn;
     private boolean morRett;
     private boolean farRett;
@@ -72,6 +84,14 @@ public class BeregnKontoerGrunnlag {
         var fd = getFødselsdato();
         var td = getTermindato().orElse(null);
         return fd.orElse(td);
+    }
+
+    public Optional<LocalDate> getRegelvalgsdato() {
+        return Optional.ofNullable(regelvalgsdato);
+    }
+
+    public LocalDate getKonfigurasjonsvalgdato() {
+        return getRegelvalgsdato().orElseGet(this::getFamiliehendelsesdato);
     }
 
     public static Builder builder() {

--- a/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnKontoerGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnKontoerGrunnlag.java
@@ -101,6 +101,11 @@ public class BeregnKontoerGrunnlag {
     public static class Builder {
         private final BeregnKontoerGrunnlag kladd = new BeregnKontoerGrunnlag();
 
+        public Builder regelvalgsdato(LocalDate regelvalgsdato) {
+            kladd.regelvalgsdato = regelvalgsdato;
+            return this;
+        }
+
         public Builder antallBarn(int antallBarn) {
             kladd.antallBarn = antallBarn;
             return this;

--- a/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnMinsterettGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnMinsterettGrunnlag.java
@@ -1,8 +1,21 @@
 package no.nav.foreldrepenger.stønadskonto.regelmodell.grunnlag;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 public class BeregnMinsterettGrunnlag {
+
+    /*
+     * Normalt velges konti ut fra fødselsdato/termindato/omsorgsdato.
+     * Normalt vil endringer tre i kraft "for nye tilfelle" - som enten går på familiehendelsedato eller på første uttaksdato.
+     * For regler som gjelder begge foreldrene brukes gjerne familiehendelsesdato. Andre regler som er mer individuelt orientert ser gjerne på uttaksdato
+     *
+     * For tilfelle terminbasert søknad så vil man på søknadstidspunktet ikke nødvendigvis vite om fødselsdato tilsier annet regelverk enn termin.
+     * Dessuten trer nye regler først i kraft når dagens dato har passert ikraftredelsesdato for endrete regler - må innvilges på gamle regler inntil nye trer i kraft
+     *
+     * Parameter regelvalgsdato settes kun når man ønsker å "overstyre" familiehendelsedato for regelvalg og kan brukes i utviklingsmiljø + produksjon fram til ikrafttredelse.
+     */
+    private LocalDate regelvalgsdato;
 
     private boolean minsterett;
     private boolean morHarUføretrygd;
@@ -56,6 +69,14 @@ public class BeregnMinsterettGrunnlag {
 
     public LocalDate getFamilieHendelseDatoNesteSak() {
         return familieHendelseDatoNesteSak;
+    }
+
+    public Optional<LocalDate> getRegelvalgsdato() {
+        return Optional.ofNullable(regelvalgsdato);
+    }
+
+    public LocalDate getKonfigurasjonsvalgdato() {
+        return getRegelvalgsdato().orElseGet(this::getFamilieHendelseDato);
     }
 
     public static class Builder {

--- a/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnMinsterettGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/grunnlag/BeregnMinsterettGrunnlag.java
@@ -83,6 +83,11 @@ public class BeregnMinsterettGrunnlag {
 
         private BeregnMinsterettGrunnlag grunnlag = new BeregnMinsterettGrunnlag();
 
+        public Builder regelvalgsdato(LocalDate regelvalgsdato) {
+            grunnlag.regelvalgsdato = regelvalgsdato;
+            return this;
+        }
+
         public Builder minsterett(boolean minsterett) {
             grunnlag.minsterett =  minsterett;
             return this;

--- a/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/konfig/Konfigurasjon.java
+++ b/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/konfig/Konfigurasjon.java
@@ -1,11 +1,28 @@
 package no.nav.foreldrepenger.stønadskonto.regelmodell.konfig;
 
-import static java.time.LocalDate.*;
-import static java.time.Month.DECEMBER;
+import static java.time.Month.AUGUST;
 import static java.time.Month.JANUARY;
 import static java.time.Month.JULY;
-import static no.nav.foreldrepenger.stønadskonto.regelmodell.grunnlag.Dekningsgrad.*;
-import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.*;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.grunnlag.Dekningsgrad.DEKNINGSGRAD_100;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.grunnlag.Dekningsgrad.DEKNINGSGRAD_80;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.BARE_FAR_RETT_DAGER_MINSTERETT;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.BARE_FAR_RETT_MOR_UFØR_DAGER_MINSTERETT;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.BARE_FAR_RETT_MOR_UFØR_DAGER_UTEN_AKTIVITETSKRAV;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.EKSTRA_DAGER_TO_BARN;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FAR_DAGER_RUNDT_FØDSEL;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FAR_TETTE_SAKER_DAGER_MINSTERETT;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FEDREKVOTE_DAGER;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FELLESPERIODE_DAGER;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FORELDREPENGER_BARE_FAR_RETT_DAGER;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FORELDREPENGER_FAR_ALENEOMSORG_DAGER;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FORELDREPENGER_FØR_FØDSEL;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.FORELDREPENGER_MOR_ALENEOMSORG_DAGER;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.MOR_TETTE_SAKER_DAGER_ADOPSJON;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.MOR_TETTE_SAKER_DAGER_FØDSEL;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.MØDREKVOTE_DAGER;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.PREMATURUKER_ANTALL_DAGER_FØR_TERMIN;
+import static no.nav.foreldrepenger.stønadskonto.regelmodell.konfig.Parametertype.TETTE_SAKER_MELLOMROM_UKER;
 
 import java.time.LocalDate;
 import java.util.Collection;
@@ -17,6 +34,12 @@ import no.nav.foreldrepenger.stønadskonto.regelmodell.grunnlag.Dekningsgrad;
 
 public class Konfigurasjon {
 
+    private static final LocalDate DATO_TIDLIGST = LocalDate.of(2010, JANUARY, 1);
+    private static final LocalDate DATO_VEDTAK = LocalDate.of(2019, JANUARY, 1);
+    private static final LocalDate DATO_PREMATUR = LocalDate.of(2019, JULY, 1);
+    private static final LocalDate DATO_MINSTERETT_1 = LocalDate.of(2022, AUGUST, 2);
+
+
     public static final Konfigurasjon STANDARD = KonfigurasjonBuilder.create()
         /*
          * Stønadskontoer
@@ -25,46 +48,48 @@ public class Konfigurasjon {
          * - FAB 2/8-2022
          */
         // Stønadskontoer
-        .leggTilParameter(MØDREKVOTE_DAGER, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 75)
-        .leggTilParameter(FEDREKVOTE_DAGER, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 75)
-        .leggTilParameter(MØDREKVOTE_DAGER, DEKNINGSGRAD_80, of(2019, JANUARY, 1), null, 95)
-        .leggTilParameter(FEDREKVOTE_DAGER, DEKNINGSGRAD_80, of(2019, JANUARY, 1), null, 95)
-        .leggTilParameter(MØDREKVOTE_DAGER, DEKNINGSGRAD_80, of(2010, JANUARY, 1), of(2018, DECEMBER, 31), 75)
-        .leggTilParameter(FEDREKVOTE_DAGER, DEKNINGSGRAD_80, of(2010, JANUARY, 1), of(2018, DECEMBER, 31), 75)
+        .leggTilParameter(MØDREKVOTE_DAGER, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 75)
+        .leggTilParameter(FEDREKVOTE_DAGER, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 75)
+        .leggTilParameter(FELLESPERIODE_DAGER, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 80)
 
-        .leggTilParameter(FELLESPERIODE_DAGER, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 80)
-        .leggTilParameter(FELLESPERIODE_DAGER, DEKNINGSGRAD_80, of(2019, JANUARY, 1), null, 90)
-        .leggTilParameter(FELLESPERIODE_DAGER, DEKNINGSGRAD_80, of(2010, JANUARY, 1), of(2018, DECEMBER, 31), 130)
-        .leggTilParameter(FORELDREPENGER_MOR_ALENEOMSORG_DAGER, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 230)
-        .leggTilParameter(FORELDREPENGER_MOR_ALENEOMSORG_DAGER, DEKNINGSGRAD_80, of(2010, JANUARY, 1), null, 280)
-        .leggTilParameter(FORELDREPENGER_FAR_ALENEOMSORG_DAGER, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 230)
-        .leggTilParameter(FORELDREPENGER_FAR_ALENEOMSORG_DAGER, DEKNINGSGRAD_80, of(2010, JANUARY, 1), null, 280)
-        .leggTilParameter(FORELDREPENGER_BARE_FAR_RETT_DAGER, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 200)
-        .leggTilParameter(FORELDREPENGER_BARE_FAR_RETT_DAGER, DEKNINGSGRAD_80, of(2010, JANUARY, 1), null, 250)
-        .leggTilParameter(FORELDREPENGER_FØR_FØDSEL, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 15)
-        .leggTilParameter(FORELDREPENGER_FØR_FØDSEL, DEKNINGSGRAD_80, of(2010, JANUARY, 1), null, 15)
+        .leggTilParameter(MØDREKVOTE_DAGER, DEKNINGSGRAD_80, DATO_VEDTAK, null, 95)
+        .leggTilParameter(FEDREKVOTE_DAGER, DEKNINGSGRAD_80, DATO_VEDTAK, null, 95)
+        .leggTilParameter(FELLESPERIODE_DAGER, DEKNINGSGRAD_80, DATO_VEDTAK, null, 90)
+
+        .leggTilParameter(MØDREKVOTE_DAGER, DEKNINGSGRAD_80, DATO_TIDLIGST, DATO_VEDTAK.minusDays(1), 75)
+        .leggTilParameter(FEDREKVOTE_DAGER, DEKNINGSGRAD_80, DATO_TIDLIGST, DATO_VEDTAK.minusDays(1), 75)
+        .leggTilParameter(FELLESPERIODE_DAGER, DEKNINGSGRAD_80, DATO_TIDLIGST, DATO_VEDTAK.minusDays(1), 130)
+
+        .leggTilParameter(FORELDREPENGER_MOR_ALENEOMSORG_DAGER, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 230)
+        .leggTilParameter(FORELDREPENGER_MOR_ALENEOMSORG_DAGER, DEKNINGSGRAD_80, DATO_TIDLIGST, null, 280)
+        .leggTilParameter(FORELDREPENGER_FAR_ALENEOMSORG_DAGER, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 230)
+        .leggTilParameter(FORELDREPENGER_FAR_ALENEOMSORG_DAGER, DEKNINGSGRAD_80, DATO_TIDLIGST, null, 280)
+        .leggTilParameter(FORELDREPENGER_BARE_FAR_RETT_DAGER, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 200)
+        .leggTilParameter(FORELDREPENGER_BARE_FAR_RETT_DAGER, DEKNINGSGRAD_80, DATO_TIDLIGST, null, 250)
+        .leggTilParameter(FORELDREPENGER_FØR_FØDSEL, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 15)
+        .leggTilParameter(FORELDREPENGER_FØR_FØDSEL, DEKNINGSGRAD_80, DATO_TIDLIGST, null, 15)
 
         // Ekstradager og Minsteretter
-        .leggTilParameter(EKSTRA_DAGER_TO_BARN, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 85)
-        .leggTilParameter(EKSTRA_DAGER_TO_BARN, DEKNINGSGRAD_80, of(2010, JANUARY, 1), null, 105)
-        .leggTilParameter(EKSTRA_DAGER_TRE_ELLER_FLERE_BARN, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 230)
-        .leggTilParameter(EKSTRA_DAGER_TRE_ELLER_FLERE_BARN, DEKNINGSGRAD_80, of(2010, JANUARY, 1), null, 280)
-        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_UTEN_AKTIVITETSKRAV, DEKNINGSGRAD_100, of(2010, JANUARY, 1), null, 75)
-        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_UTEN_AKTIVITETSKRAV, DEKNINGSGRAD_80, of(2010, JANUARY, 1), null, 95)
-        .leggTilParameter(BARE_FAR_RETT_DAGER_MINSTERETT, of(2017, JANUARY, 1), null, 40) // TODO: endre til aug 2022 etter overgang
-        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_MINSTERETT, DEKNINGSGRAD_100, of(2017, JANUARY, 1), null, 75) // TODO: endre til aug 2022 etter overgang
-        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_MINSTERETT, DEKNINGSGRAD_80, of(2017, JANUARY, 1), null, 95) // TODO: endre til aug 2022 etter overgang
-        .leggTilParameter(FAR_DAGER_RUNDT_FØDSEL, of(2017, JANUARY, 1), null, 10) // TODO: endre til aug 2022 etter overgang
-        .leggTilParameter(MOR_TETTE_SAKER_DAGER_FØDSEL, of(2017, JANUARY, 1), null, 110) // TODO: endre til aug 2022 etter overgang
-        .leggTilParameter(MOR_TETTE_SAKER_DAGER_ADOPSJON, of(2017, JANUARY, 1), null, 40) // TODO: endre til aug 2022 etter overgang
-        .leggTilParameter(FAR_TETTE_SAKER_DAGER_MINSTERETT, of(2017, JANUARY, 1), null, 40) // TODO: endre til aug 2022 etter overgang
+        .leggTilParameter(EKSTRA_DAGER_TO_BARN, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 85)
+        .leggTilParameter(EKSTRA_DAGER_TO_BARN, DEKNINGSGRAD_80, DATO_TIDLIGST, null, 105)
+        .leggTilParameter(EKSTRA_DAGER_TRE_ELLER_FLERE_BARN, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 230)
+        .leggTilParameter(EKSTRA_DAGER_TRE_ELLER_FLERE_BARN, DEKNINGSGRAD_80, DATO_TIDLIGST, null, 280)
+        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_UTEN_AKTIVITETSKRAV, DEKNINGSGRAD_100, DATO_TIDLIGST, null, 75)
+        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_UTEN_AKTIVITETSKRAV, DEKNINGSGRAD_80, DATO_TIDLIGST, null, 95)
+        .leggTilParameter(BARE_FAR_RETT_DAGER_MINSTERETT, DATO_MINSTERETT_1, null, 40)
+        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_MINSTERETT, DEKNINGSGRAD_100, DATO_MINSTERETT_1, null, 75)
+        .leggTilParameter(BARE_FAR_RETT_MOR_UFØR_DAGER_MINSTERETT, DEKNINGSGRAD_80, DATO_MINSTERETT_1, null, 95)
+        .leggTilParameter(FAR_DAGER_RUNDT_FØDSEL, DATO_MINSTERETT_1, null, 10)
+        .leggTilParameter(MOR_TETTE_SAKER_DAGER_FØDSEL, DATO_MINSTERETT_1, null, 110)
+        .leggTilParameter(MOR_TETTE_SAKER_DAGER_ADOPSJON, DATO_MINSTERETT_1, null, 40)
+        .leggTilParameter(FAR_TETTE_SAKER_DAGER_MINSTERETT, DATO_MINSTERETT_1, null, 40)
 
         // Grenser
-        .leggTilParameter(TETTE_SAKER_MELLOMROM_UKER, of(2017, JANUARY, 1), null, 48)  // TODO: endre til aug 2022 el 48 uker tidligere etter overgang
-        .leggTilParameter(PREMATURUKER_ANTALL_DAGER_FØR_TERMIN, of(2019, JULY, 1), null, 52)
+        .leggTilParameter(TETTE_SAKER_MELLOMROM_UKER, DATO_MINSTERETT_1, null, 48)
+        .leggTilParameter(PREMATURUKER_ANTALL_DAGER_FØR_TERMIN, DATO_PREMATUR, null, 52)
         .build();
 
-    public static final LocalDate PREMATURUKER_REGELENDRING_START_DATO = of(2019, 7, 1);
+    public static final LocalDate PREMATURUKER_REGELENDRING_START_DATO = DATO_PREMATUR;
 
     private final Map<Parametertype, Collection<Parameter>> parameterMap = new EnumMap<>(Parametertype.class);
 

--- a/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/regler/OpprettKontoer.java
+++ b/src/main/java/no/nav/foreldrepenger/stønadskonto/regelmodell/regler/OpprettKontoer.java
@@ -40,7 +40,7 @@ class OpprettKontoer extends LeafSpecification<BeregnKontoerGrunnlag> {
         // Opprette alle kontoer utenom samtidig uttak
         for (var kontokonfigurasjon : kontokonfigurasjoner) {
             if (kontokonfigurasjon.stønadskontotype() != StønadskontoBeregningStønadskontotype.FLERBARNSDAGER) {
-                var antallDager = Konfigurasjon.STANDARD.getParameter(kontokonfigurasjon.parametertype(), grunnlag.getDekningsgrad(), grunnlag.getFamiliehendelsesdato());
+                var antallDager = Konfigurasjon.STANDARD.getParameter(kontokonfigurasjon.parametertype(), grunnlag.getDekningsgrad(), grunnlag.getKonfigurasjonsvalgdato());
                 antallDager += getFlerbarnsdager(grunnlag, kontoerMap, antallExtraBarnDager, kontokonfigurasjon);
                 if (kontotypeSomKanHaEkstraFlerbarnsdager(kontokonfigurasjon) && skalLeggeTilPrematurUker(grunnlag)) {
                     antallPrematurDager = antallVirkedagerFomFødselTilTermin(grunnlag);
@@ -81,7 +81,7 @@ class OpprettKontoer extends LeafSpecification<BeregnKontoerGrunnlag> {
     private int finnEkstraFlerbarnsdager(BeregnKontoerGrunnlag grunnlag) {
         for (var kontokonfigurasjon : kontokonfigurasjoner) {
             if (kontokonfigurasjon.stønadskontotype() == StønadskontoBeregningStønadskontotype.FLERBARNSDAGER) {
-                return Konfigurasjon.STANDARD.getParameter(kontokonfigurasjon.parametertype(), grunnlag.getDekningsgrad(), grunnlag.getFamiliehendelsesdato());
+                return Konfigurasjon.STANDARD.getParameter(kontokonfigurasjon.parametertype(), grunnlag.getDekningsgrad(), grunnlag.getKonfigurasjonsvalgdato());
             }
         }
         return 0;


### PR DESCRIPTION
Kommenter gjerne på parameternavn og metodenavn

Tanken er om lag slik: Sak + Api har en klassemetode som legger på regelvalgsdato ved behov i overgangsfaser
* Produksjon - bruker regelvalg = dagensdato fram til ikrafttredelsen er passert, etter det settes ikke regelvalgsdato
* Testmiljø(Q) - mer tilpasset til testing før ikrafttredelse
* Verdikjede/lokal test: Kjører med en umiddelbar ikrafttredelsesdato etter at tester er lagt om ti ny default + laget regresjonstest for eldre tilfelle (gamle regler)
* Enhetstest: Kan kjøre med dato etter ikrafttredelse fram til ikraftredelse passert. Regresjonstester sørger for tidligere regelvalg